### PR TITLE
#7 DB export script hotfix

### DIFF
--- a/scripts/apply_snapshot.sh
+++ b/scripts/apply_snapshot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source ../.env
+. ../.env
 
 env=$APP_ENV
 host=$DB_HOST

--- a/scripts/export_database.sh
+++ b/scripts/export_database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-source ../.env
+. ../.env
 
 env=$APP_ENV
 host=$DB_HOST


### PR DESCRIPTION
Followup to #9

Turns out ubuntu doesn't support `source`, so I'm changing it to `.`